### PR TITLE
Several improvements

### DIFF
--- a/pareto/uidfixer/browser/uidfixer-results.pt
+++ b/pareto/uidfixer/browser/uidfixer-results.pt
@@ -32,6 +32,7 @@
             <tr>
               <th>URL of document containing link</th>
               <th>field</th>
+              <th>link type</th>
               <th>link href</th>
               <th>found target url</th>
             </tr>
@@ -40,10 +41,13 @@
             <tal:block repeat="result results">
               <tr>
                 <td style="white-space: nowrap">
-                  <a tal:attributes="href result/object/absolute_url; class python:result['resolved'] and 'resolved' or 'unresolved'; style python:result['resolved'] and 'color: blue' or 'color: red'" tal:content="python: '...' + result['object'].absolute_url()[-80:]"></a>
+                  <a tal:attributes="href result/source; class python:result['resolved'] and 'resolved' or 'unresolved'; style python:result['resolved'] and 'color: blue' or 'color: red'" tal:content="result/source"></a>
                 </td>
                 <td>
                   <strong tal:content="result/field|nothing"></strong>
+                </td>
+                <td>
+                  <strong tal:content="result/link_type|nothing"></strong>
                 </td>
                 <td style="white-space: nowrap">
                   <em tal:content="result/href"></em>

--- a/pareto/uidfixer/browser/uidfixer.py
+++ b/pareto/uidfixer/browser/uidfixer.py
@@ -36,7 +36,7 @@ class UIDFixerView(BrowserView):
         """ return a nicely formatted list of objects for a template """
         portal_catalog = self.context.portal_catalog
         return [{
-            'object': context,
+            'source': context.absolute_url(),
             'field': field,
             'link_type': link_type,
             'href': href,
@@ -90,6 +90,7 @@ class UIDFixerView(BrowserView):
                                     'src="%s%s"' % (href, rest),
                                     'src="resolveuid/%s%s"' % (uid,rest))
                                 fixed = True
+                            portlet = "portlet '%s' " % portlet.get('name')
                             yield (context, portlet, href, uid, link_type)
                         if fixed and not self.request.get('dry'):
                             assignment.text = html

--- a/pareto/uidfixer/browser/uidfixer.py
+++ b/pareto/uidfixer/browser/uidfixer.py
@@ -90,8 +90,8 @@ class UIDFixerView(BrowserView):
                                     'src="%s%s"' % (href, rest),
                                     'src="resolveuid/%s%s"' % (uid,rest))
                                 fixed = True
-                            portlet = "portlet '%s' " % portlet.get('name')
-                            yield (context, portlet, href, uid, link_type)
+                            name = "portlet '%s' " % portlet.get('name')
+                            yield (context, name, href, uid, link_type)
                         if fixed and not self.request.get('dry'):
                             assignment.text = html
                             assignment._p_changed = True

--- a/pareto/uidfixer/browser/uidfixer.py
+++ b/pareto/uidfixer/browser/uidfixer.py
@@ -106,17 +106,14 @@ class UIDFixerView(BrowserView):
             html = field.getRaw(context)
             fixed = False
             for href, uid, rest, link_type in self.find_uids(html, context):
-                if not uid:
-                    # html = html.replace(href, 'UNRESOLVED:/%s' % (uid,))
-                    continue
-                else:
+                if uid:
                     html = html.replace(
                         'href="%s%s"' % (href, rest),
                         'href="resolveuid/%s%s"' % (uid, rest))
                     html = html.replace(
                         'src="%s%s"' % (href, rest),
                         'src="resolveuid/%s%s"' % (uid,rest))
-                fixed = True
+                    fixed = True
                 yield (context, fieldname, href, uid, link_type)
             if fixed and not self.request.get('dry'):
                 field.set(context, html)

--- a/pareto/uidfixer/browser/uidfixer.py
+++ b/pareto/uidfixer/browser/uidfixer.py
@@ -146,9 +146,10 @@ class UIDFixerView(BrowserView):
 
         if skip_links and any([link in href for link in skip_links if link]):
             raise KeyError
-                
-        if href.endswith('/'):
-            href = href[:-1]
+
+        for suffix in ['/', '/view', '/at_download/file']:
+            if href.endswith(suffix):
+                href = href[:-len(suffix)]
         chunks = [urllib.unquote(chunk) for chunk in href.split('/')]
         while chunks:
             chunk = chunks[0]
@@ -179,7 +180,7 @@ class UIDFixerView(BrowserView):
 
     _reg_href = re.compile(r'href="([^"]+)"')
     _reg_src = re.compile(r'src="([^"]+)"')
-    
+
     def find_uids(self, html, context):
         while True:
             match = self._reg_href.search(html)
@@ -196,7 +197,6 @@ class UIDFixerView(BrowserView):
                     href = href[:href.find(s)]
             html = html.replace(match.group(0), '')
             scheme, netloc, path, params, query, fragment = urlparse(href)
-            # import pdb; pdb.set_trace()
             if (href and not scheme and not netloc and not href.lower().startswith('resolveuid/')):
                 # relative link, convert to resolveuid one
                 uid = self.convert_link(href, context)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(name='pareto.uidfixer',
           # -*- Extra requirements: -*-
       ],
       entry_points="""
-      # -*- Entry points: -*-
+      [z3c.autoinclude.plugin]
+      target = plone
       """,
       )


### PR DESCRIPTION
* Show link type (img or a)
* Pass only strings to template instead of thousands of objects
* Actually show broken links for content in results
* Ignore trailing /view and /at_download/file when resolving targets